### PR TITLE
jchoover: WIXBUG:6071 - Enable HTTP to HTTPS redirects for burn downl…

### DIFF
--- a/src/dutil/dlutil.cpp
+++ b/src/dutil/dlutil.cpp
@@ -558,7 +558,11 @@ static HRESULT OpenRequest(
     {
         dwRequestFlags |= INTERNET_FLAG_SECURE;
     }
-
+    else if (INTERNET_SCHEME_HTTP == scheme)
+    {
+        dwRequestFlags |= INTERNET_FLAG_IGNORE_REDIRECT_TO_HTTPS;
+    }
+    
     // Allocate the resource name.
     hr = StrAllocString(&sczResource, wzResource, 0);
     ExitOnFailure(hr, "Failed to allocate string for resource URI.");


### PR DESCRIPTION
Didn't see an obvious place in 4.x to add a MD for the history.