### PR TITLE
Add OsRtlGetVersion

### DIFF
--- a/src/Cpp.Build.props
+++ b/src/Cpp.Build.props
@@ -12,6 +12,10 @@
     <WindowsTargetPlatformVersion>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetLatestSDKTargetPlatformVersion('Windows', '10.0'))</WindowsTargetPlatformVersion>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)CustomizedNativeRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+
   <ItemDefinitionGroup>
     <ClCompile>
       <DisableSpecificWarnings>$(DisableSpecificCompilerWarnings)</DisableSpecificWarnings>

--- a/src/CustomizedNativeRecommendedRules.ruleset
+++ b/src/CustomizedNativeRecommendedRules.ruleset
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Customized Microsoft Native Recommended Rules" Description="Microsoft Native Recommended Rules, -C26812" ToolsVersion="16.0">
+  <Include Path="nativerecommendedrules.ruleset" Action="Default" />
+  <Rules AnalyzerId="Microsoft.Analyzers.NativeCodeAnalysis" RuleNamespace="Microsoft.Rules.Native">
+    <!-- We need C style enums since we support BAs written in C -->
+    <Rule Id="C26812" Action="None" />
+  </Rules>
+</RuleSet>

--- a/src/dutil/dutil.vcxproj
+++ b/src/dutil/dutil.vcxproj
@@ -83,10 +83,7 @@
     <ClCompile Include="memutil.cpp" />
     <ClCompile Include="metautil.cpp" />
     <ClCompile Include="monutil.cpp" />
-    <ClCompile Include="osutil.cpp">
-      <!-- turn off deprecation warning -->
-      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
-    </ClCompile>
+    <ClCompile Include="osutil.cpp" />
     <ClCompile Include="path2utl.cpp" />
     <ClCompile Include="pathutil.cpp" />
     <ClCompile Include="perfutil.cpp" />

--- a/src/dutil/inc/osutil.h
+++ b/src/dutil/inc/osutil.h
@@ -33,6 +33,9 @@ HRESULT DAPI OsIsRunningPrivileged(
 HRESULT DAPI OsIsUacEnabled(
     __out BOOL* pfUacEnabled
     );
+HRESULT DAPI OsRtlGetVersion(
+    __inout RTL_OSVERSIONINFOEXW* pOvix
+    );
 
 #ifdef __cplusplus
 }

--- a/src/dutil/osutil.cpp
+++ b/src/dutil/osutil.cpp
@@ -22,7 +22,14 @@ extern "C" void DAPI OsGetVersion(
     if (OS_VERSION_UNKNOWN == vOsVersion)
     {
         ovi.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEXW);
+
+#pragma warning (push)
+#pragma warning(suppress: 4996) // deprecated
+#pragma warning (push)
+#pragma warning(suppress: 28159)// deprecated, use other function instead
         ::GetVersionExW(reinterpret_cast<OSVERSIONINFOW*>(&ovi)); // only fails if version info size is set incorrectly.
+#pragma warning (pop)
+#pragma warning (pop)
 
         vdwOsServicePack = static_cast<DWORD>(ovi.wServicePackMajor) << 16 | ovi.wServicePackMinor;
         if (4 == ovi.dwMajorVersion)

--- a/src/test/DUtilUnitTest/DUtilUnitTest.vcxproj
+++ b/src/test/DUtilUnitTest/DUtilUnitTest.vcxproj
@@ -70,7 +70,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\dutil\dutil.vcxproj" />
+    <ProjectReference Include="..\..\dutil\dutil.vcxproj">
+      <Project>{1244E671-F108-4334-BA52-8A7517F26ECD}</Project>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Import Project="..\..\..\packages\WixBuildTools.TestSupport.Native.4.0.47\build\WixBuildTools.TestSupport.Native.targets" Condition="Exists('..\..\..\packages\WixBuildTools.TestSupport.Native.4.0.47\build\WixBuildTools.TestSupport.Native.targets')" />


### PR DESCRIPTION
Ignore enum CA warnings and scope the osutil deprecation warning suppression.
Also, fix project reference so the .vcx project system understands it.

https://github.com/wixtoolset/issues/issues/6318